### PR TITLE
Add a Composer branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     },
 	"autoload": {
 		"psr-0": { "AFM": "src/" }
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.0.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
Just means that this library can be required with:

```json
albertofem/rsync-lib": "1.0@dev"
```

Working around stability flags as required.